### PR TITLE
Upgrade version

### DIFF
--- a/blogofile/__init__.py
+++ b/blogofile/__init__.py
@@ -7,4 +7,4 @@ Please take a moment to read LICENSE.txt. It's short.
 """
 
 __author__ = "Ryan McGuire, Doug Latornell, and the Blogofile Contributors"
-__version__ = '0.8.3'
+__version__ = '0.8.4'


### PR DESCRIPTION
So that one can get rid of the -py3k textile requirement by specifying a version constraint on blogofile